### PR TITLE
Preelaborate

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,4 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: alire-project/setup-alire@v1
+        with:
+          version: 1.2.0
+      - run: alr index "--add=git+https://github.com/alire-project/alire-index#gnat_n_gnatprove_12" --name=gnat_fsf_12 --before=community
       - run: cd tests; bash -x build_all.sh

--- a/alire.toml
+++ b/alire.toml
@@ -23,7 +23,7 @@ tags = ["embedded", "arm", "nostd"]
 
 [[depends-on]]
 hal = "~0.3"
-gnat_arm_elf = ">=11"
+gnat_arm_elf = ">=12"
 
 [configuration.variables]
 core = { type = "Enum", values = ["m0", "m0p", "m4", "m4f", "m7f", "m7df"] }

--- a/cortex_m.gpr
+++ b/cortex_m.gpr
@@ -26,7 +26,7 @@ project Cortex_M is
                                           "src/nvic_cm4_cm7");
    end case;
 
-   ZFP_Runtime := "zfp-cortex-" & Cortex_M_Config.core;
+   Light_Runtime := "light-cortex-" & Cortex_M_Config.core;
 
    for Source_Dirs use ("src/", "config/") & Core_Src_Dirs;
    for Object_Dir use "obj/" & Cortex_M_Config.Build_Profile;

--- a/src/cortex_m-cache.ads
+++ b/src/cortex_m-cache.ads
@@ -35,6 +35,7 @@
 with System;
 
 package Cortex_M.Cache is
+   pragma Elaborate_Body;
 
    procedure Enable_I_Cache;
 

--- a/src/cortex_m-debug.ads
+++ b/src/cortex_m-debug.ads
@@ -30,6 +30,7 @@
 ------------------------------------------------------------------------------
 
 package Cortex_M.Debug is
+   pragma Preelaborate;
 
    function Halting_Debug_Enabled return Boolean;
 

--- a/src/cortex_m-hints.ads
+++ b/src/cortex_m-hints.ads
@@ -39,6 +39,7 @@
 --    https://developer.arm.com/documentation/ddi0419/e
 
 package Cortex_M.Hints is
+   pragma Preelaborate;
 
    procedure Send_Event with Inline;
    --  A6.7.57 SEV

--- a/src/cortex_m-systick.ads
+++ b/src/cortex_m-systick.ads
@@ -32,6 +32,7 @@
 with HAL;
 
 package Cortex_M.Systick is
+   pragma Preelaborate;
 
    type Clock_Source is (CPU_Clock, External_Clock);
 

--- a/src/fpu/cortex_m-fpu.ads
+++ b/src/fpu/cortex_m-fpu.ads
@@ -47,6 +47,7 @@
 with HAL; use HAL;
 
 package Cortex_M.FPU is
+   pragma Preelaborate;
 
    function Sqrt (X : Float) return Float;
 

--- a/src/memory_barriers.ads
+++ b/src/memory_barriers.ads
@@ -32,6 +32,7 @@
 --  This file provides utility functions for ARM Cortex microcontrollers
 
 package Memory_Barriers is
+   pragma Preelaborate;
 
    procedure Data_Synchronization_Barrier with Inline;
    --  Injects instruction "DSB Sy" i.e., a "full system" domain barrier

--- a/src/nvic_cm0/cortex_m-nvic.ads
+++ b/src/nvic_cm0/cortex_m-nvic.ads
@@ -44,9 +44,8 @@
 
 with HAL;                  use HAL;
 
-package Cortex_M.NVIC
-   with Preelaborate
-is  -- the Nested Vectored Interrupt Controller
+package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
+   pragma Preelaborate;
 
    NVIC_PRIO_BITS : constant := 2;
    --  All Cortex M0 parts have 2 bit priority mask

--- a/src/nvic_cm0/cortex_m-nvic.ads
+++ b/src/nvic_cm0/cortex_m-nvic.ads
@@ -44,7 +44,9 @@
 
 with HAL;                  use HAL;
 
-package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
+package Cortex_M.NVIC
+   with Preelaborate
+is  -- the Nested Vectored Interrupt Controller
 
    NVIC_PRIO_BITS : constant := 2;
    --  All Cortex M0 parts have 2 bit priority mask

--- a/src/nvic_cm4_cm7/cortex_m-nvic.ads
+++ b/src/nvic_cm4_cm7/cortex_m-nvic.ads
@@ -46,6 +46,7 @@ with System;
 with HAL;            use HAL;
 
 package Cortex_M.NVIC is  -- the Nested Vectored Interrupt Controller
+   pragma Elaborate_Body;
 
    type Interrupt_ID is new Natural range 0 .. 240;
    type Interrupt_Priority is new UInt32;

--- a/src/semihosting-filesystem.ads
+++ b/src/semihosting-filesystem.ads
@@ -38,6 +38,7 @@ with HAL.Filesystem; use HAL.Filesystem;
 with HAL; use HAL;
 
 package Semihosting.Filesystem is
+   pragma Preelaborate;
 
    type SHFS is new HAL.Filesystem.Filesystem_Driver with private;
    type Any_SHFS is access all SHFS'Class;

--- a/src/semihosting.ads
+++ b/src/semihosting.ads
@@ -33,6 +33,7 @@ with System;
 with HAL;
 
 package Semihosting is
+   pragma Preelaborate;
 
    type SH_Word is new HAL.UInt32;
 

--- a/tests/alire.toml
+++ b/tests/alire.toml
@@ -10,7 +10,7 @@ executables = ["tests"]
 
 [[depends-on]]
 cortex_m = "*"
-gnat_arm_elf = "^11.2.2"
+gnat_arm_elf = "^12.1"
 
 [[pins]]
 cortex_m = { path='..' }
@@ -19,4 +19,4 @@ cortex_m = { path='..' }
 cortex_m = "validation"
 
 [configuration.values]
-cortex_m.core = "m0"
+cortex_m.core = "m7df"

--- a/tests/tests.gpr
+++ b/tests/tests.gpr
@@ -10,7 +10,7 @@ project Tests is
    for Main use ("tests.adb");
 
    for Target use "arm-eabi";
-   for Runtime ("Ada") use Cortex_M.ZFP_Runtime;
+   for Runtime ("Ada") use Cortex_M.Light_Runtime;
 
    package Compiler is
       for Default_Switches ("Ada") use Tests_Config.Ada_Compiler_Switches;


### PR DESCRIPTION
This shouldn't be merged until GNAT 12 is in the community index, but I'm eager to get the cortex-m stuff preelaborated.

The first commit on this branch just preelaborates `Cortex_M.NVIC`, which is the only thing I *need* right now.

The second commit adds Preelaborate or Elaborate_Body to every spec.

The third commit updates the tests and runtime for GNAT 12.