### PR TITLE
Version 0.4.0

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -13,7 +13,7 @@ Library](https://github.com/AdaCore/Ada_Drivers_Library/) repo.
 '''
 
 name = "cortex_m"
-version = "0.4.0-dev"
+version = "0.4.0"
 licenses = "BSD-3-Clause"
 authors=["AdaCore"]
 website="https://github.com/AdaCore/Ada_Drivers_Library/"


### PR DESCRIPTION
I'd like to get 0.4.0 published to alire so that I can release the next version of rp2040_hal that depends on it.